### PR TITLE
Fix panic in table rendering

### DIFF
--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -69,9 +69,7 @@ impl StatefulTable {
                             .pool_hour_data
                             .iter()
                             .last()
-                            .unwrap()
-                            .volume_usd
-                            .parse::<f64>()
+                            .and_then(|d| d.volume_usd.parse::<f64>().ok())
                             .unwrap_or(0.0)
                     ),
                     if pos.liquidity.parse::<f64>().unwrap_or(0.0) > 0.0 {


### PR DESCRIPTION
## Summary
- fix runtime panic when a position has no pool_hour_data

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68408cfd0e208327af9738f60bb355e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or invalid data in position updates to prevent app crashes. If data is unavailable or malformed, a default value is used instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->