### PR TITLE
Enhance positions table and live orders

### DIFF
--- a/src/network/limit_orders.rs
+++ b/src/network/limit_orders.rs
@@ -132,8 +132,10 @@ fn format_number(num: f64) -> String {
 pub async fn fetch_limit_orders(app: Arc<Mutex<App>>) -> Result<()> {
     log::debug!("Starting to fetch limit orders");
 
-    // Check if we should use mock data (for testing and development)
-    let use_mock_data = false; // TODO: Make this configurable
+    // Check if we should use mock data from environment variable
+    let use_mock_data = std::env::var("USE_MOCK_DATA")
+        .map(|v| v.to_lowercase() == "true")
+        .unwrap_or(false);
 
     if use_mock_data {
         log::info!("Using mock limit order data for testing");

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -80,6 +80,28 @@ impl StatefulTable {
                         "X".to_string()
                     },
                     age_str,
+                    {
+                        let deposited0 = pos.deposited_token0.parse::<f64>().unwrap_or(0.0);
+                        let deposited1 = pos.deposited_token1.parse::<f64>().unwrap_or(0.0);
+                        let withdrawn0 = pos.withdrawn_token0.parse::<f64>().unwrap_or(0.0);
+                        let withdrawn1 = pos.withdrawn_token1.parse::<f64>().unwrap_or(0.0);
+
+                        let last = pos.pool.pool_hour_data.last();
+                        let token0_price = last
+                            .and_then(|d| d.token0_price.as_ref())
+                            .or_else(|| Some(&pos.pool.token0_price))
+                            .and_then(|p| p.parse::<f64>().ok())
+                            .unwrap_or(0.0);
+                        let token1_price = last
+                            .and_then(|d| d.token1_price.as_ref())
+                            .or_else(|| Some(&pos.pool.token1_price))
+                            .and_then(|p| p.parse::<f64>().ok())
+                            .unwrap_or(0.0);
+
+                        let fees0 = (withdrawn0 - deposited0).max(0.0) * token0_price;
+                        let fees1 = (withdrawn1 - deposited1).max(0.0) * token1_price;
+                        format!("${:.2}", fees0 + fees1)
+                    },
                 ]
             })
             .collect();
@@ -209,10 +231,11 @@ pub fn render_table<'a>(
             Constraint::Length(20),
             Constraint::Length(20),
             Constraint::Length(20),
+            Constraint::Length(20),
         ],
     )
     .header(
-        Row::new(vec!["Pool", "Token0", "Token1", "Value"])
+        Row::new(vec!["Pool", "Token0", "Token1", "Value", "Fees"])
             .style(Style::default().fg(Color::Yellow))
             .height(1)
             .bottom_margin(5),


### PR DESCRIPTION
## Summary
- show historical fees for each position
- pull live limit orders instead of mock data
- filter limit orders by wallet address

## Testing
- `cargo check`
- `cargo test`
- `cargo clippy` *(fails: component not installed)*
- `cargo fmt` *(fails: component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68408e08ecb083278c73bfa71b1985d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Fees" column to the positions table, displaying earned fees in dollar value for each position.

- **Bug Fixes**
  - Limit orders are now filtered to only show those matching the connected wallet address. Mock data for limit orders is controlled by an environment variable and disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->